### PR TITLE
feat(backend): enhance health endpoint with system metrics

### DIFF
--- a/backend/routes/health.js
+++ b/backend/routes/health.js
@@ -1,13 +1,31 @@
 import { Router } from 'express';
+import { sessionStore } from '../services/sessionStore.js';
 
 const router = Router();
+const startedAt = Date.now();
+
+function formatBytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${mb.toFixed(1)}MB`;
+}
 
 router.get('/', (req, res) => {
+  const mem = process.memoryUsage();
   res.json({
     status: 'ok',
     service: 'MigraOps Backend',
     version: '5.0.0',
     timestamp: new Date().toISOString(),
+    uptime: Math.floor((Date.now() - startedAt) / 1000),
+    node: process.version,
+    memory: {
+      rss: formatBytes(mem.rss),
+      heapUsed: formatBytes(mem.heapUsed),
+      heapTotal: formatBytes(mem.heapTotal),
+    },
+    sessions: {
+      active: sessionStore.list().length,
+    },
     config: {
       anthropic: !!process.env.ANTHROPIC_API_KEY,
       github: !!process.env.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary
- GET `/api/health` ahora retorna métricas del sistema:
  - `uptime` — segundos desde inicio del servidor
  - `node` — versión de Node.js (e.g. v22.14.0)
  - `memory` — RSS, heapUsed, heapTotal en MB
  - `sessions.active` — número de sesiones activas en el store

## Issues
Closes #36

## Response example
```json
{
  "status": "ok",
  "service": "MigraOps Backend",
  "version": "5.0.0",
  "uptime": 3600,
  "node": "v22.14.0",
  "memory": { "rss": "85.2MB", "heapUsed": "42.1MB", "heapTotal": "65.0MB" },
  "sessions": { "active": 3 },
  "config": { "anthropic": true, "github": true }
}
```

## Test plan
- [x] Endpoint responde con nuevos campos
- [x] Valores son correctos (uptime incrementa, memory refleja uso real)
- [x] Backward compatible (campos originales se mantienen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)